### PR TITLE
keypair: don't use ec2_utils

### DIFF
--- a/nixopspacket/resources/keypair.py
+++ b/nixopspacket/resources/keypair.py
@@ -67,7 +67,7 @@ class PacketKeyPairState(nixops.resources.ResourceState):
     def create(self, defn, check, allow_reboot, allow_recreate):
 
         # TODO: Fix Me
-        self.access_key_id = defn.access_key_id or nixops.ec2_utils.get_access_key_id()
+        self.access_key_id = defn.access_key_id
         self.project = defn.project
         if not self.access_key_id:
             raise Exception("please set ‘accessKeyId’, $PACKET_ACCESS_KEY")


### PR DESCRIPTION
ec2_utils isn't present in nixops master