### PR TITLE
Changes to the code based on upstreamed packet-python PRs

### DIFF
--- a/nixopspacket/backends/device.py
+++ b/nixopspacket/backends/device.py
@@ -42,7 +42,7 @@ class PacketDefinition(MachineDefinition):
         self.spotPriceMax = config["packet"]["spotPriceMax"]
 
         if config["packet"]["reservationId"] is None:
-            self.reservationId = False
+            self.reservationId = ""
         else:
             self.reservationId = config["packet"]["reservationId"]
 

--- a/release.nix
+++ b/release.nix
@@ -8,10 +8,10 @@ let
   version = "1.6.1" + (if officialRelease then "" else "pre${toString nixopsSrc.revCount}_${nixopsSrc.shortRev}");
   packet = pkgs.python2Packages.packet-python.overrideAttrs (old: {
     src = pkgs.fetchFromGitHub {
-      owner = "input-output-hk";
+      owner = "grahamc";
       repo = "packet-python";
-      rev = "0aa7e7e9a7009b89d09f2dfa8d32a222d89bb829";
-      sha256 = "15z869idd3h399grq61ssn0xhs24zhy7x4i63yg8xlhvar7mgvls";
+      rev = "9d9e60a2db9949162d216e5a983ff1284cec34f1";
+      sha256 = "14p1pgiabj2dj60kd2y9hmyail9s3yph8mxbymxpx6l5zfdmy2jl";
     };
     patches = [];
     buildInputs = old.buildInputs ++ [ pkgs.python2Packages.pytestrunner ];

--- a/release.nix
+++ b/release.nix
@@ -8,10 +8,10 @@ let
   version = "1.6.1" + (if officialRelease then "" else "pre${toString nixopsSrc.revCount}_${nixopsSrc.shortRev}");
   packet = pkgs.python2Packages.packet-python.overrideAttrs (old: {
     src = pkgs.fetchFromGitHub {
-      owner = "grahamc";
+      owner = "packethost";
       repo = "packet-python";
-      rev = "9d9e60a2db9949162d216e5a983ff1284cec34f1";
-      sha256 = "14p1pgiabj2dj60kd2y9hmyail9s3yph8mxbymxpx6l5zfdmy2jl";
+      rev = "v1.42.0";
+      sha256 = "16nsq7bg9588cqiw3d7xqdps0lgv1s6dsjivawf3kjxnkz5ldliy";
     };
     patches = [];
     buildInputs = old.buildInputs ++ [ pkgs.python2Packages.pytestrunner ];


### PR DESCRIPTION
I upstreamed most of the patches in https://github.com/packethost/packet-python/compare/03165b26c6e740e1157d3a7e7df6cd3b6a2750e1...0aa7e7e9a7009b89d09f2dfa8d32a222d89bb829 (input-output-hk:hardware-reservation's branch at this time) in PRs:

* https://github.com/packethost/packet-python/pull/71 device: capture hardware reservation
* https://github.com/packethost/packet-python/pull/72 create_device: support customdata
* https://github.com/packethost/packet-python/pull/73 device: capture spot_price_max, termination_time, provisioning_percentage
* https://github.com/packethost/packet-python/pull/74 plan: intake available_in
* https://github.com/packethost/packet-python/pull/75 manager: add create_project_ssh_key: 

The only commit in https://github.com/packethost/packet-python/compare/03165b26c6e740e1157d3a7e7df6cd3b6a2750e1...0aa7e7e9a7009b89d09f2dfa8d32a222d89bb82 I didn't backport is https://github.com/packethost/packet-python/commit/e8bd41689fde2a46c08580208da25bd06e86c67d, because it is quite gnarly and I think working around an upstream issue -- I'm not sure. Anyway, this change to reservationId is the only thing I think needed -- and the second commit is just the way I've been testing the integrated branch.

Probably shouldn't merge this for now, and instead just use the upstream release once it is done.